### PR TITLE
fix: move .gitignore package-lock.json command to a separate step

### DIFF
--- a/.github/workflows/dependency-tree-update.yml
+++ b/.github/workflows/dependency-tree-update.yml
@@ -44,12 +44,16 @@ jobs:
         uses: actions/setup-node@v2
         with:
           registry-url: 'https://npm.pkg.github.com'
+      - name: Remove package-lock.json entry from .gitignore.
+        run: |
+          if [ -f .gitignore ]; then
+            sed -i '/package-lock.json/d' .gitignore;
+          fi;
       - name: Update dependency tree.
         id: update
         working-directory:  ${{ inputs.path }}
         run: |
           rm -rf node_modules;
-          sed -i '/package-lock.json/d' .gitignore;
           if [ -f package-lock.json ]; then
             rm package-lock.json;
             npm install;


### PR DESCRIPTION
The command to remove the `package-lock.json` entry from the `.gitignore` file was falling when the folder for the `package.json` file was different than the root directory. Changing the command to a different step mitigates that.