### PR TITLE
fix: remove yarn.lock from .gitignore before running workflow

### DIFF
--- a/.github/workflows/dependency-tree-update.yml
+++ b/.github/workflows/dependency-tree-update.yml
@@ -44,10 +44,11 @@ jobs:
         uses: actions/setup-node@v2
         with:
           registry-url: 'https://npm.pkg.github.com'
-      - name: Remove package-lock.json entry from .gitignore.
+      - name: Remove package-lock.json and yarn.lock entries from .gitignore.
         run: |
           if [ -f .gitignore ]; then
             sed -i '/package-lock.json/d' .gitignore;
+            sed -i '/yarn.lock/d' .gitignore;
           fi;
       - name: Update dependency tree.
         id: update

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ By regenerating the lockfiles, the dependency tree will be updated to pull in th
 
 None of these updates should be a breaking change, since they respect the [version ranges](https://semver.npmjs.com/). They'll potentially save you and your team a lot of time by preventing `Dependabot` vulnerability alerts that you'd have to deal with manually otherwise. 
 
-The lock file will be generated using the `npm`/`yarn` version that matches the `node` version specified on the `.nvmrc` file for your project. The workflow also removes entries for `package-lock.json` on your `.gitignore` file.
+The lock file will be generated using the `npm`/`yarn` version that matches the `node` version specified on the `.nvmrc` file for your project. The workflow also removes entries for `package-lock.json` or `yarn.lock` on your `.gitignore` file.
 
 To enable it for a repo, create a new workflow with the following contents:
 


### PR DESCRIPTION
Beforehand only `package-lock.json` entires were being removed from the `.gitignore` file.