### PR TITLE
chore: change token used for auto-updater

### DIFF
--- a/.github/workflows/dependency-tree-update.yml
+++ b/.github/workflows/dependency-tree-update.yml
@@ -88,7 +88,7 @@ jobs:
         uses: tradeshift/create-pull-request@v3
         with:
           commit-message: 'chore: update dependency tree for ${{ steps.formatPath.outputs.path }}/package.json'
-          token: ${{ secrets.github-token }}
+          token: ${{ github.token }}
           committer: ${{ steps.configure.outputs.user }}
           author: ${{ steps.configure.outputs.user }}
           title: 'chore: update dependency tree'
@@ -107,7 +107,7 @@ jobs:
         if: ${{ failure() && !cancelled() }}
         uses: actions/github-script@v6
         with:
-          github-token: ${{ secrets.github-token }}
+          github-token: ${{ github.token }}
           script: |
             github.rest.issues.create({
               issue_number: context.issue.number,


### PR DESCRIPTION
With that, we can hopefully mitigate the issue we currently have with Github's API secondary rate limits making workflow runs fail.