### PR TITLE
chore: change of ownership from developer-productivity to sre

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @Tradeshift/developer-productivity @Tradeshift/ci-workers
+* @Tradeshift/sre @Tradeshift/ci-workers

--- a/Repofile
+++ b/Repofile
@@ -1,7 +1,7 @@
 {
     "description": "This is actions-workflow-npm",
     "maintainers": [
-        "developer-productivity"
+        "sre"
     ],
     "checks": [
         "build"

--- a/catalog-info.yml
+++ b/catalog-info.yml
@@ -9,4 +9,4 @@ metadata:
 spec:
   type: other
   lifecycle: experimental
-  owner: "developer-productivity"
+  owner: "sre"


### PR DESCRIPTION
This PR changes the ownership of this repo to SRE, as the developer productivity team doesn't exist anymore.