### PR TITLE
[VULN-12828] guard comment-npm-publish against untrusted commenters

### DIFF
--- a/.github/workflows/comment-npm-publish.yml
+++ b/.github/workflows/comment-npm-publish.yml
@@ -10,9 +10,16 @@ on:
 
 jobs:
   npm-publish:
-    # This job only runs for pull request comments
+    # This job only runs for the 'npm publish' comment on a pull request, and
+    # only when the commenter has write access (org member, repo owner, or
+    # collaborator). Without the author_association guard, any GitHub user could
+    # trigger arbitrary PR code execution and an npm publish on the self-hosted
+    # runner simply by commenting on a fork PR.
     name: npm publish
-    if: github.event.comment.body == 'npm publish'
+    if: >-
+      github.event.issue.pull_request
+      && github.event.comment.body == 'npm publish'
+      && contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
     runs-on: [self-hosted, ts-large-x64-docker-large]
     steps:
       - name: "📦 Update comment"


### PR DESCRIPTION
> Jira: **VULN-12828** — HackerOne report #3854463

## Summary

Fixes a **critical** unauthenticated RCE / supply-chain vulnerability in the reusable `comment-npm-publish.yml` workflow (VULN-12828 / HackerOne report #3854463).

The `npm-publish` job triggered on **any** `issue_comment` whose body equalled `npm publish`, with the comment body as the sole guard — no check on the commenter's identity or permissions:

```yaml
if: github.event.comment.body == 'npm publish'
```

Because `issue_comment` fires for any GitHub user, anyone could:

1. Fork a consuming repo (e.g. `g11n-langneg`, `http-mockserver`),
2. Add a malicious `preinstall`/`build` script to `package.json`,
3. Open a PR and comment `npm publish`.

The workflow then checks out the attacker's PR code and runs `npm ci`, `npm run build`, and `npm publish --tag=pre` on a **persistent self-hosted runner** with `npm-read-token` and `github-token` in the environment — yielding arbitrary code execution on internal CI infrastructure, secret exfiltration, and a malicious publish under the `@tradeshift` namespace.

## Fix

Restrict the job to pull-request comments from users with write access:

```yaml
if: >-
  github.event.issue.pull_request
  && github.event.comment.body == 'npm publish'
  && contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
```

- `github.event.issue.pull_request` — ensures the comment is on a PR, not a plain issue.
- `author_association` allowlist — only org owners, org members, and repo collaborators (i.e. write access) can trigger the publish. Outside contributors and anonymous users are rejected.

## Rollout note

`@v1` is a moving tag; consumers (`g11n-langneg`, `http-mockserver`, …) pick up the fix once the `v1` tag is moved to include this commit after merge.