### PR TITLE
fix: guard comment-npm-publish against untrusted commenters (VULN-12828)

### DIFF
--- a/.github/workflows/comment-npm-publish.yml
+++ b/.github/workflows/comment-npm-publish.yml
@@ -10,9 +10,18 @@ on:
 
 jobs:
   npm-publish:
-    # This job only runs for pull request comments
+    # This job only runs for the 'npm publish' comment on a pull request, and
+    # only when the commenter is a Tradeshift org member or the repo owner.
+    # Without the author_association guard, any GitHub user could trigger
+    # arbitrary PR code execution and an npm publish on the self-hosted runner
+    # simply by commenting on a fork PR. COLLABORATOR is intentionally excluded:
+    # it matches outside collaborators (including read-only), so it would leave
+    # a hole for accounts outside the org.
     name: npm publish
-    if: github.event.comment.body == 'npm publish'
+    if: >-
+      github.event.issue.pull_request
+      && github.event.comment.body == 'npm publish'
+      && contains(fromJSON('["OWNER", "MEMBER"]'), github.event.comment.author_association)
     runs-on: [self-hosted, ts-large-x64-docker-large]
     steps:
       - name: "📦 Update comment"


### PR DESCRIPTION
> Jira: **VULN-12828** — HackerOne report #3854463

## Summary

Fixes a **critical** unauthenticated RCE / supply-chain vulnerability in the reusable `comment-npm-publish.yml` workflow (VULN-12828 / HackerOne report #3854463).

The `npm-publish` job triggered on **any** `issue_comment` whose body equalled `npm publish`, with the comment body as the sole guard — no check on the commenter's identity or permissions:

```yaml
if: github.event.comment.body == 'npm publish'
```

Because `issue_comment` fires for any GitHub user, anyone could:

1. Fork a consuming repo (e.g. `g11n-langneg`, `http-mockserver`),
2. Add a malicious `preinstall`/`build` script to `package.json`,
3. Open a PR and comment `npm publish`.

The workflow then checks out the attacker's PR code and runs `npm ci`, `npm run build`, and `npm publish --tag=pre` on a **persistent self-hosted runner** with `npm-read-token` and `github-token` in the environment — yielding arbitrary code execution on internal CI infrastructure, secret exfiltration, and a malicious publish under the `@tradeshift` namespace.

## Fix

Restrict the job to pull-request comments from **Tradeshift org members and the repo owner**:

```yaml
if: >-
  github.event.issue.pull_request
  && github.event.comment.body == 'npm publish'
  && contains(fromJSON('["OWNER", "MEMBER"]'), github.event.comment.author_association)
```

- `github.event.issue.pull_request` — ensures the comment is on a PR, not a plain issue.
- `author_association` allowlist — only `OWNER` and `MEMBER` (org members) can trigger the publish. `COLLABORATOR` is **intentionally excluded**: it matches anyone added directly to the repo, including outside (non-org) collaborators with even read-only access, which would leave a hole for accounts outside Tradeshift. Outside contributors and anonymous users are rejected.

## Rollout note

`@v1` is a moving tag; consumers (`g11n-langneg`, `http-mockserver`, …) pick up the fix once the `v1` tag is moved to include this commit after merge.